### PR TITLE
修改package.json文件适配node18

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service serve --open",
+    "serve": "SET NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service serve --open",
     "build": "vue-cli-service build"
   },
   "dependencies": {


### PR DESCRIPTION
今天在启动vue时一直报错，网上查证说node v17之后发布了OpenSSL3.0对算法和秘钥的大小增加了更为严格的限制，因此vue一直无法启动。解决此方法可以将node版本回退到v16之前；如果不想更改版本，可以修改package.json文件，在script的serve中添加了SET NODE_OPTIONS=--openssl-legacy-provider。我在此对其进行了修改